### PR TITLE
Avoid repeated call of write(2) system call

### DIFF
--- a/lib/fluent/plugin/out_keep_forward.rb
+++ b/lib/fluent/plugin/out_keep_forward.rb
@@ -200,6 +200,9 @@ class Fluent::KeepForwardOutput < Fluent::ForwardOutput
   end
 
   def sock_write(sock, tag, chunk)
+    oldsync = sock.sync
+    sock.sync = false
+
     # beginArray(2)
     sock.write FORWARD_HEADER
 
@@ -221,6 +224,10 @@ class Fluent::KeepForwardOutput < Fluent::ForwardOutput
 
     # writeRawBody(packed_es)
     chunk.write_to(sock)
+
+  ensure
+    sock.sync = oldsync
+    sock.flush # for immediate call of write(2)
   end
 
   # watcher thread callback


### PR DESCRIPTION
Looking at `strace(1)` outputs, I found those `TCPSocket#write`s immediately resulted in `write(2)` system calls each time, which are HEAVY.