### PR TITLE
Add config descriptions

### DIFF
--- a/lib/fluent/plugin/out_keep_forward.rb
+++ b/lib/fluent/plugin/out_keep_forward.rb
@@ -8,9 +8,20 @@ class Fluent::KeepForwardOutput < Fluent::ForwardOutput
     define_method("log") { $log }
   end
 
+  desc "Switch connection to a recovered node from standby nodes or less weighted nodes."
   config_param :prefer_recover, :bool, :default => true
+  desc "Keepalive connection."
   config_param :keepalive, :bool, :default => false
-  config_param :keepalive_time, :time, :default => nil # infinite
+  desc <<-DESC
+Keepalive expired time.
+Default is nil (which means to keep connection as long as possible).
+DESC
+  config_param :keepalive_time, :time, :default => nil
+  desc <<-DESC
+The transport protocol to use for heartbeats.
+The default is “udp”, but you can select “tcp” as well.
+Furthermore, in keep_forward, you can also select "none" to disable heartbeat.
+DESC
   config_param :keepforward, :default => :one do |val|
     case val.downcase
     when 'one'
@@ -23,6 +34,11 @@ class Fluent::KeepForwardOutput < Fluent::ForwardOutput
       raise ::Fluent::ConfigError, "out_keep_forward keepforward should be 'one' or 'thread', or 'tag'"
     end
   end
+  desc <<-DESC
+The transport protocol to use for heartbeats.
+The default is “udp”, but you can select “tcp” as well.
+Furthermore, in keep_forward, you can also select "none" to disable heartbeat.
+DESC
   config_param :heartbeat_type, :default => :udp do |val|
     case val.downcase
     when 'tcp'

--- a/lib/fluent/plugin/out_keep_forward.rb
+++ b/lib/fluent/plugin/out_keep_forward.rb
@@ -8,6 +8,14 @@ class Fluent::KeepForwardOutput < Fluent::ForwardOutput
     define_method("log") { $log }
   end
 
+  # For fluentd v0.12.16 or earlier
+  class << self
+    unless method_defined?(:desc)
+      def desc(description)
+      end
+    end
+  end
+
   desc "Switch connection to a recovered node from standby nodes or less weighted nodes."
   config_param :prefer_recover, :bool, :default => true
   desc "Keepalive connection."


### PR DESCRIPTION
With fluentd 0.12.19, config descriptions are shown like this:

``` log
$ bundle exec fluentd --show-plugin-config output:keep_forward -p lib/fluent/plugin/
2016-01-15 11:58:56 +0900 [info]: Show config for output:keep_forward
2016-01-15 11:58:56 +0900 [info]: 
log_level: string: <nil> # Allows the user to set different levels of logging for each plugin.
buffer_type: string: <"memory">
flush_interval: time: <60>
try_flush_interval: float: <1>
disable_retry_limit: bool: <false>
retry_limit: integer: <17>
retry_wait: time: <1.0>
max_retry_wait: time: <nil>
num_threads: integer: <1>
queued_chunk_flush_interval: time: <1>
send_timeout: time: <60> # The timeout time when sending event logs.
heartbeat_type: : <:udp> # The transport protocol to use for heartbeats.(udp,tcp,none)
heartbeat_interval: time: <1> # The interval of the heartbeat packer.
recover_wait: time: <10> # The wait time before accepting a server fault recovery.
hard_timeout: time: <60> # The hard timeout used to detect server failure.
expire_dns_cache: time: <nil> # Set TTL to expire DNS cache in seconds.
phi_threshold: integer: <16> # The threshold parameter used to detect server faults.
phi_failure_detector: bool: <true> # Use the "Phi accrual failure detector" to detect server failure.
require_ack_response: bool: <false> # Change the protocol to at-least-once.
ack_response_timeout: time: <190> # This option is used when require_ack_response is true.
dns_round_robin: bool: <false> # Enable client-side DNS round robin.
port: integer: <24224>
host: string: <nil>
prefer_recover: bool: <true> # Switch connection to a recovered node from standby nodes or less weighted nodes.
keepalive: bool: <false> # Keepalive connection.
keepalive_time: time: <nil> # Keepalive expired time.
Default is nil (which means to keep connection as long as possible).

keepforward: : <:one> # The transport protocol to use for heartbeats.
The default is “udp”, but you can select “tcp” as well.
Furthermore, in keep_forward, you can also select "none" to disable heartbeat.

heartbeat_type: : <:udp> # The transport protocol to use for heartbeats.
The default is “udp”, but you can select “tcp” as well.
Furthermore, in keep_forward, you can also select "none" to disable heartbeat.
```
